### PR TITLE
Use getUserByEmail in ensureUser

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -225,9 +225,8 @@ async function ensureUser(
 
     if (!user) {
       // Check if user already exists by email (for development mode)
-      const existingUser = await storage.getAllUsers();
-      const userByEmail = existingUser.find(u => u.email === req.user!.email);
-      
+      const userByEmail = await storage.getUserByEmail(req.user!.email);
+
       if (userByEmail) {
         // User exists with this email, use the existing user
         user = userByEmail;


### PR DESCRIPTION
## Summary
- look up users by email directly instead of loading all users when ensuring a user exists

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: Cannot find name 'User', parameter 'n' implicitly any, processedAt type incompatibility)*

------
https://chatgpt.com/codex/tasks/task_b_68c819f2fcb4832cb45b4a5a3a6b1cfc