### PR TITLE
chore: remove unused users import from routes

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -22,7 +22,6 @@ import {
   adminRemovePointsSchema,
   adminSetPointsSchema,
   updateRedemptionStatusSchema,
-  users,
 } from "@shared/schema";
 import {
   initializeActionHandlers,


### PR DESCRIPTION
## Summary
- clean up @shared/schema imports in server routes by removing unused `users`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: Cannot find name 'User'; Parameter 'n' implicitly has an 'any' type; Type '{ id: ... }' is not assignable)*

------
https://chatgpt.com/codex/tasks/task_b_68c819f17b54832ca5df916d384ac8e7