### PR TITLE
Fix profile fetch hanging by using configurable API base

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -16,7 +16,7 @@ import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
 import AdminPanel from "./components/AdminPanel";
 import TransactionHistory from "./pages/TransactionHistory";
-import type { Reward, RewardCategory } from "@shared/schema";
+import type { Reward, RewardCategory, User } from "@shared/schema";
 
 // Icon mapping for rewards
 const getRewardIcon = (title: string) => {
@@ -335,9 +335,9 @@ function Dashboard() {
                       </div>
                     </div>
                     <Avatar>
-                      <AvatarImage src={displayUser?.photoURL} alt={displayUser?.displayName} />
+                      <AvatarImage src={displayUser?.photoURL || undefined} alt={displayUser?.displayName || undefined} />
                       <AvatarFallback className="bg-purple-600 text-white" data-testid="avatar-fallback">
-                        {displayUser?.displayName?.split(' ').map(n => n[0]).join('') || 'U'}
+                        {displayUser?.displayName?.split(' ').map((n: string) => n[0]).join('') || 'U'}
                       </AvatarFallback>
                     </Avatar>
                   </div>

--- a/client/src/lib/auth.tsx
+++ b/client/src/lib/auth.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useEffect, useState } from "react";
 import { User, onAuthStateChanged } from "firebase/auth";
 import { auth, signInWithGoogle, signOutUser } from "./firebase";
+import { apiRequest } from "./queryClient";
 
 interface AuthUser {
   id: string;
@@ -61,22 +62,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const fetchOrCreateUser = async (firebaseUser: User): Promise<AuthUser> => {
     try {
-      // Get the Firebase ID token
-      const idToken = await firebaseUser.getIdToken();
-      
-      // Call our backend API with the token (same origin)
-      const response = await fetch('/api/user/profile', {
-        method: 'GET',
-        headers: {
-          'Authorization': `Bearer ${idToken}`,
-          'Content-Type': 'application/json',
-        },
-      });
-
-      if (!response.ok) {
-        throw new Error(`Failed to fetch user profile: ${response.statusText}`);
-      }
-
+      // Use the shared API request helper to ensure consistent
+      // authentication headers and API base URL across environments.
+      const response = await apiRequest('GET', '/api/user/profile');
       const userData = await response.json();
       
       return {

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -2,12 +2,11 @@ import { QueryClient, QueryFunction } from "@tanstack/react-query";
 import { auth } from "./firebase";
 
 function getApiUrl(url: string): string {
-  // Always use Replit domain for API calls in production
-  const isProduction = window.location.hostname !== 'localhost';
-  const apiBaseUrl = isProduction 
-    ? 'https://0fcf04b4-ca17-4bd2-9e9f-28767ae1dec3-00-3rzl653kiaiv1.janeway.replit.dev'
-    : '';
-  
+  // Allow overriding the API base URL via environment variable, defaulting
+  // to same-origin requests. This prevents hard-coding deployment specific
+  // domains and keeps the client flexible across environments.
+  const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || '';
+
   return `${apiBaseUrl}${url}`;
 }
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -212,11 +212,12 @@ export class MemStorage implements IStorage {
 
   async createRedemption(redemption: InsertRedemption, tx?: TransactionHandle): Promise<Redemption> {
     const id = randomUUID();
-    return { 
-      ...redemption, 
-      id, 
+    return {
+      ...redemption,
+      id,
       status: redemption.status ?? "pending",
-      redeemedAt: new Date() 
+      redeemedAt: new Date(),
+      processedAt: redemption.processedAt ?? null,
     };
   }
 


### PR DESCRIPTION
## Summary
- allow setting API base through `VITE_API_BASE_URL` and default to same-origin
- use shared `apiRequest` helper in auth provider to ensure proper headers
- fix TypeScript issues and default `processedAt` in in-memory storage

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_68c8226d6018832c9227af65eac3e155